### PR TITLE
Adjust message in send_after call

### DIFF
--- a/lib/referrer_blocklist.ex
+++ b/lib/referrer_blocklist.ex
@@ -31,7 +31,9 @@ defmodule ReferrerBlocklist do
     updated_blocklist = attempt_blocklist_update(resource_url, state.blocklist)
 
     Process.cancel_timer(state[:timer])
-    new_timer = Process.send_after(self(), :update_list, @update_interval_milliseconds)
+
+    new_timer =
+      Process.send_after(self(), {:update_list, resource_url}, @update_interval_milliseconds)
 
     {:noreply, %{state | blocklist: updated_blocklist, timer: new_timer}}
   end


### PR DESCRIPTION
Small issue - currently there are `FunctionClauseError`s for trying to pattern match on just `:update_list` in `ReferrerBlocklist.handle_info/2` function.